### PR TITLE
Change data type and run all test cases

### DIFF
--- a/fe_region_growth.cpp
+++ b/fe_region_growth.cpp
@@ -3,16 +3,16 @@
 short arr_in_img[BREADTH][LENGTH] = {{0}};
 short arr_out_img[BREADTH + 2][LENGTH + 2];
 
-void getData(short arr_out_img[BREADTH + 2][LENGTH + 2], int i, int j, int star_num, int x_sum[], int y_sum[], int pixel_sum[], int num_pixels[])
+void getData(short arr_out_img[BREADTH + 2][LENGTH + 2], unsigned short i, unsigned short j, unsigned short star_num, unsigned short x_sum[], unsigned short y_sum[], unsigned short pixel_sum[], unsigned short num_pixels[])
 {
 	// base case
 	if(arr_out_img[j][i] <= THRESHOLD)
 		return;
 	
 	// keeping track of the sums
-	x_sum[star_num] += (int)arr_out_img[j][i]*i;
-	y_sum[star_num] += (int)arr_out_img[j][i]*j;
-	pixel_sum[star_num] += (int)arr_out_img[j][i];
+	x_sum[star_num] += (unsigned short)arr_out_img[j][i]*i;
+	y_sum[star_num] += (unsigned short)arr_out_img[j][i]*j;
+	pixel_sum[star_num] += (unsigned short)arr_out_img[j][i];
 	num_pixels[star_num] += 1;
 	arr_out_img[j][i] = 0;
 
@@ -35,35 +35,39 @@ void padZeroes(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH + 2]
 				arr_out_img[i][j] = arr_in_img[i-1][j-1];
 }
 
-void regionGrowth(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH + 2][LENGTH + 2], double centroids_st[MAX_STARS][3])
+void regionGrowth(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH + 2][LENGTH + 2], double centroids_st[MAX_STARS][3], unsigned short img_num)
 {
-	int star_num = 0;
+	unsigned short star_num = 0;
 	padZeroes(arr_in_img, arr_out_img);
-	int x_sum[MAX_STARS] = {0};
-	int y_sum[MAX_STARS] = {0};
-	int pixel_sum[MAX_STARS] = {0};
-	int num_pixels[MAX_STARS] = {0};
-	for(int j = 1; j < BREADTH + 1; j += SKIP_PIXELS)
-		for(int i = 1; i < LENGTH + 1; i += SKIP_PIXELS)
+	unsigned short x_sum[MAX_STARS] = {0};
+	unsigned short y_sum[MAX_STARS] = {0};
+	unsigned short pixel_sum[MAX_STARS] = {0};
+	unsigned short num_pixels[MAX_STARS] = {0};
+	for(unsigned short j = 1; j < BREADTH + 1; j += SKIP_PIXELS)
+		for(unsigned short i = 1; i < LENGTH + 1; i += SKIP_PIXELS)
 			if(arr_out_img[j][i] > THRESHOLD)
 			{
 				getData(arr_out_img, i, j, star_num, x_sum, y_sum, pixel_sum, num_pixels);
 				star_num++;
 			}
 	ofstream out;
-	out.open("centroid_data.csv");
+	char datafile[25];
+	sprintf(datafile, "Results/centroid data %i.csv", img_num);
+	out.open(datafile);
 	out<<"x_sum, y_sum, pixel_sum, num_pixels\n";
-	for(int i = 0; i < MAX_STARS; i++)
+	for(unsigned short i = 0; i < MAX_STARS; i++)
 	{
 		out<<x_sum[i]<<","<<y_sum[i]<<","<<pixel_sum[i]<<","<<num_pixels[i]<<"\n";
 	}
 	out.close();
-	int valid_stars = 0;
+	unsigned short valid_stars = 0;
 	
 	ofstream cen;
-	cen.open("centroids.csv");
+	char cenfile[25];
+	sprintf(cenfile, "Results/centroids %i.csv", img_num);
+	cen.open(cenfile);
 	cen<<"ID, x_cen, y_cen\n";
-	for(int k = 0; k < star_num; k++)
+	for(unsigned short k = 0; k < star_num; k++)
 	{
 		if((num_pixels[k] <= STAR_MAX_PIXEL) & (num_pixels[k] > STAR_MIN_PIXEL))
 		{
@@ -81,16 +85,23 @@ void regionGrowth(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH +
 int main()
 {
     double centroids_st[MAX_STARS][3];
-	ifstream file;
-    file.open("image.txt");
-	for(int i = 0; i < BREADTH; i++)
-		for(int j = 0; j < LENGTH; j++)
-			file >> arr_in_img[i][j];
-	auto start = high_resolution_clock::now();
+	for(unsigned short img_num = 1; img_num < 16; img_num++)
+	{
+		// making the appropriate filename
+		ifstream file;
+		char filename[25];
+        sprintf(filename, "Test Images/image %i.txt", img_num);
+		file.open(filename);
+		//reading the array
+		for(unsigned short i = 0; i < BREADTH; i++)
+			for(unsigned short j = 0; j < LENGTH; j++)
+				file >> arr_in_img[i][j];
+		auto start = high_resolution_clock::now();
 
-	regionGrowth(arr_in_img, arr_out_img, centroids_st);
+		regionGrowth(arr_in_img, arr_out_img, centroids_st, img_num);
 
-	auto stop = high_resolution_clock::now();
-	auto duration = duration_cast<milliseconds>(stop - start);
-	cout<<"Time taken: " <<duration.count()<<" ms";
+		auto stop = high_resolution_clock::now();
+		auto duration = duration_cast<milliseconds>(stop - start);
+		cout<<"Time taken: " <<duration.count()<<" ms";
+	}
 }

--- a/fe_region_growth.cpp
+++ b/fe_region_growth.cpp
@@ -2,6 +2,7 @@
 
 short arr_in_img[BREADTH][LENGTH] = {{0}};
 short arr_out_img[BREADTH + 2][LENGTH + 2];
+char datafile[25], cenfile[25];
 
 void getData(short arr_out_img[BREADTH + 2][LENGTH + 2], unsigned short i, unsigned short j, unsigned short star_num, unsigned short x_sum[], unsigned short y_sum[], unsigned short pixel_sum[], unsigned short num_pixels[])
 {
@@ -51,7 +52,6 @@ void regionGrowth(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH +
 				star_num++;
 			}
 	ofstream out;
-	char datafile[25];
 	sprintf(datafile, "Results/centroid data %i.csv", img_num);
 	out.open(datafile);
 	out<<"x_sum, y_sum, pixel_sum, num_pixels\n";
@@ -63,7 +63,6 @@ void regionGrowth(short arr_in_img[BREADTH][LENGTH], short arr_out_img[BREADTH +
 	unsigned short valid_stars = 0;
 	
 	ofstream cen;
-	char cenfile[25];
 	sprintf(cenfile, "Results/centroids %i.csv", img_num);
 	cen.open(cenfile);
 	cen<<"ID, x_cen, y_cen\n";
@@ -102,6 +101,6 @@ int main()
 
 		auto stop = high_resolution_clock::now();
 		auto duration = duration_cast<milliseconds>(stop - start);
-		cout<<"Time taken: " <<duration.count()<<" ms";
+		cout<<"Time taken: " <<duration.count()<<" ms"<<endl;
 	}
 }


### PR DESCRIPTION
This branch changes the datatype for the image arrays from int to short, to prevent wastage of space. It also runs through all the test cases at once.